### PR TITLE
Bugfix to dialect for describe table

### DIFF
--- a/src/databricks/sqlalchemy/dialect/__init__.py
+++ b/src/databricks/sqlalchemy/dialect/__init__.py
@@ -287,7 +287,7 @@ class DatabricksDialect(default.DefaultDialect):
         DBR_GT_12_NOT_FOUND_STRING = "TABLE_OR_VIEW_NOT_FOUND"
 
         try:
-            res = connection.execute(f"DESCRIBE TABLE {table_name}")
+            res = connection.execute(f"DESCRIBE TABLE `{schema}`.{table_name}")
             return True
         except DatabaseError as e:
             if DBR_GT_12_NOT_FOUND_STRING in str(


### PR DESCRIPTION
- has_table did not include schema in the 'DESCRIBE TABLE" SQL. 
- This is now included. And allows the alembic_version table to be stored within different schemas to default.