### PR TITLE
Fix/drop table default if exists

### DIFF
--- a/src/databricks/sqlalchemy/dialect/base.py
+++ b/src/databricks/sqlalchemy/dialect/base.py
@@ -118,3 +118,8 @@ class DatabricksDDLCompiler(compiler.DDLCompiler):
 
         text += f"\n){self.post_create_table(table)}\n\n"
         return text
+
+    def visit_drop_table(self, drop, **kw):
+        text = "\nDROP TABLE IF EXISTS"
+
+        return text + self.preparer.format_table(drop.element)

--- a/src/databricks/sqlalchemy/dialect/base.py
+++ b/src/databricks/sqlalchemy/dialect/base.py
@@ -120,6 +120,6 @@ class DatabricksDDLCompiler(compiler.DDLCompiler):
         return text
 
     def visit_drop_table(self, drop, **kw):
-        text = "\nDROP TABLE IF EXISTS"
+        text = "\nDROP TABLE IF EXISTS "
 
         return text + self.preparer.format_table(drop.element)


### PR DESCRIPTION
- Drop table defaulted to 'IF EXISTS' to prevent upgrades breaking due to non transactional behaviour of databricks.