### PR TITLE
Query appended with edge case

### DIFF
--- a/src/databricks/sqlalchemy/dialect/__init__.py
+++ b/src/databricks/sqlalchemy/dialect/__init__.py
@@ -256,7 +256,8 @@ class DatabricksDialect(default.DefaultDialect):
             sql_str = """SELECT table_schema, table_name
                          FROM information_schema.tables 
                          WHERE table_schema = '{}'
-                         AND table_type = 'MANAGED';""".format(
+                         AND table_type = 'MANAGED'
+                         AND table_name NOT LIKE '%_mvt';""".format(
                 schema_str
             )
             # TODO: Add if scenario for None schema


### PR DESCRIPTION
- An edge case added to our dialect changes to deliberately ignore tables with '_mvt' suffix.