### PR TITLE
 Add IF EXISTS clause to DROP VIEW statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,7 +195,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # End of https://www.toptal.com/developers/gitignore/api/python,macos
 

--- a/src/databricks/sqlalchemy/dialect/base.py
+++ b/src/databricks/sqlalchemy/dialect/base.py
@@ -154,6 +154,9 @@ class DatabricksDDLCompiler(compiler.DDLCompiler):
 
         return text + self.preparer.format_table(drop.element)
 
+    def visit_drop_view(self, drop, **kw):
+        return "\nDROP VIEW IF EXISTS " + self.preparer.format_table(drop.element)
+
 
 @compiles(ColumnComment, "databricks")
 def visit_column_comment(


### PR DESCRIPTION
Reason: In order to prevent errors when non-existing views will be dropped in an Alembic version.